### PR TITLE
(feat): move from exit to return and Run to RunE to make things testable

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -28,7 +29,7 @@ import (
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup",
 	Short: "cleanup removes all services with the tag prefix from a given consul service",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
 		}))
@@ -40,7 +41,7 @@ var cleanupCmd = &cobra.Command{
 		consulClient, err := api.NewClient(config)
 		if err != nil {
 			logger.Error("Failed to create Consul client", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to create Consul client: %w", err)
 		}
 
 		serviceID := cmd.InheritedFlags().Lookup("service-id").Value.String()
@@ -61,10 +62,11 @@ var cleanupCmd = &cobra.Command{
 		err = t.CleanupTags()
 		if err != nil {
 			logger.Error("Failed to clean up tags", "error", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to clean up tags: %w", err)
 		}
 
 		logger.Info("Tag cleanup completed successfully")
+		return nil
 	},
 }
 

--- a/cmd/cleanup_test.go
+++ b/cmd/cleanup_test.go
@@ -46,7 +46,7 @@ func TestCleanupCmd(t *testing.T) {
 			testCleanupCmd := &cobra.Command{
 				Use:   "cleanup",
 				Short: "cleanup removes all services with the tag prefix",
-				Run:   cleanupCmd.Run,
+				RunE:  cleanupCmd.RunE,
 			}
 			cmd.AddCommand(testCleanupCmd)
 
@@ -124,7 +124,7 @@ func TestCleanupCmdHelp(t *testing.T) {
 	testCleanupCmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "cleanup removes all services with the tag prefix from a given consul service",
-		Run:   cleanupCmd.Run,
+		RunE:  cleanupCmd.RunE,
 	}
 	cmd.AddCommand(testCleanupCmd)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -189,7 +189,7 @@ func TestRootCmdHelp(t *testing.T) {
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetArgs([]string{"--help"})
-	
+
 	err := rootCmd.Execute()
 	assert.NoError(t, err)
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -34,6 +34,12 @@ func TestRunCmd(t *testing.T) {
 			expectError:   true,
 			errorContains: "required flag(s) \"script\" not set",
 		},
+		{
+			name:          "Invalid interval format",
+			args:          []string{"run", "--service-id=test-service", "--script=/tmp/test.sh", "--interval=invalid"},
+			expectError:   true,
+			errorContains: "invalid interval",
+		},
 	}
 
 	for _, tt := range tests {
@@ -53,7 +59,7 @@ func TestRunCmd(t *testing.T) {
 			testRunCmd := &cobra.Command{
 				Use:   "run",
 				Short: "Run tagit",
-				Run:   runCmd.Run,
+				RunE:  runCmd.RunE,
 			}
 			cmd.AddCommand(testRunCmd)
 


### PR DESCRIPTION
This pull request refactors the error handling in the `cleanup` and `run` commands to use Cobra's recommended `RunE` pattern, improving testability and reliability. Instead of directly exiting the process on errors, the commands now return errors, allowing for better error propagation and handling in tests and higher-level code. The corresponding test files have also been updated to use the new `RunE` handlers and include additional test coverage for error cases.

**Command error handling improvements:**

* Changed `cleanupCmd` and `runCmd` from using `Run` to `RunE`, replacing direct calls to `os.Exit(1)` with returning errors for better error propagation and testability. (`cmd/cleanup.go`, `cmd/run.go`) [[1]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868L31-R32) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L39-R93)
* Updated error handling in both commands to log errors and return them, including more descriptive error messages for configuration and flag parsing failures. (`cmd/cleanup.go`, `cmd/run.go`) [[1]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868L43-R44) [[2]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868L64-R69) [[3]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L39-R93)
* Added missing import of `fmt` required for error formatting. (`cmd/cleanup.go`, `cmd/run.go`) [[1]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868R19) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R20)
* Ensured both commands return `nil` on successful completion. (`cmd/cleanup.go`, `cmd/run.go`) [[1]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868L64-R69) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R128)

**Test updates and coverage:**

* Updated all test command definitions to use the new `RunE` handlers instead of `Run`, ensuring tests work with the new error handling approach. (`cmd/cleanup_test.go`, `cmd/run_test.go`) [[1]](diffhunk://#diff-88bf4cf247b2469ebabdf721d68b5a01087e99ac1688ef053dc13b7f23dc7b7eL49-R49) [[2]](diffhunk://#diff-88bf4cf247b2469ebabdf721d68b5a01087e99ac1688ef053dc13b7f23dc7b7eL127-R127) [[3]](diffhunk://#diff-e5c6b0d9de21f1d8dee56a4b65988b10e5e74030b7dd52ef18195901e6f879adL56-R62)
* Added a new test case to check for invalid interval format handling in the `run` command. (`cmd/run_test.go`)…testable