### PR TITLE
(feat) start moving things to a factory to simplify to test

### DIFF
--- a/cmd/cleanup_test.go
+++ b/cmd/cleanup_test.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/ncode/tagit/pkg/consul"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -244,6 +247,8 @@ func TestCleanupCmdFlagRetrieval(t *testing.T) {
 
 func TestCleanupCmdSuccessFlow(t *testing.T) {
 	// Test the successful flow of cleanup command
+	// Since the actual cleanupCmd creates a real Consul client internally,
+	// we test with a mock command that simulates the successful path
 	cmd := &cobra.Command{Use: "tagit"}
 	cmd.PersistentFlags().StringP("consul-addr", "c", "127.0.0.1:8500", "consul address")
 	cmd.PersistentFlags().StringP("service-id", "s", "", "consul service id")
@@ -251,12 +256,27 @@ func TestCleanupCmdSuccessFlow(t *testing.T) {
 	cmd.PersistentFlags().StringP("tag-prefix", "p", "tagged", "prefix to be added to tags")
 	cmd.PersistentFlags().StringP("token", "t", "", "consul token")
 
+	var logOutput bytes.Buffer
 	testCleanupCmd := &cobra.Command{
 		Use:   "cleanup",
 		Short: "cleanup removes all services with the tag prefix from a given consul service",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Simulate successful cleanup without actual consul connection
-			// This tests the success path that returns nil
+			// Verify all required flags are accessible
+			serviceID := cmd.InheritedFlags().Lookup("service-id").Value.String()
+			tagPrefix := cmd.InheritedFlags().Lookup("tag-prefix").Value.String()
+			consulAddr := cmd.InheritedFlags().Lookup("consul-addr").Value.String()
+			token := cmd.InheritedFlags().Lookup("token").Value.String()
+
+			// Simulate the logging that would happen
+			fmt.Fprintf(&logOutput, "Starting tag cleanup, serviceID=%s, tagPrefix=%s, consulAddr=%s\n",
+				serviceID, tagPrefix, consulAddr)
+
+			if token != "" {
+				fmt.Fprintf(&logOutput, "Using token authentication\n")
+			}
+
+			// Simulate successful cleanup
+			fmt.Fprintf(&logOutput, "Tag cleanup completed successfully\n")
 			return nil
 		},
 	}
@@ -268,8 +288,215 @@ func TestCleanupCmdSuccessFlow(t *testing.T) {
 		"--script=/tmp/test.sh",
 		"--consul-addr=localhost:8500",
 		"--tag-prefix=test",
+		"--token=secret-token",
 	})
 
 	err := cmd.Execute()
 	assert.NoError(t, err)
+
+	// Verify the command would have executed with the right parameters
+	output := logOutput.String()
+	assert.Contains(t, output, "serviceID=test-service")
+	assert.Contains(t, output, "tagPrefix=test")
+	assert.Contains(t, output, "consulAddr=localhost:8500")
+	assert.Contains(t, output, "Using token authentication")
+	assert.Contains(t, output, "Tag cleanup completed successfully")
+}
+
+// MockConsulClient for testing
+type MockConsulClient struct {
+	MockAgent consul.ConsulAgent
+}
+
+func (m *MockConsulClient) Agent() consul.ConsulAgent {
+	return m.MockAgent
+}
+
+// MockAgent implements the ConsulAgent interface
+type MockAgent struct {
+	ServiceFunc         func(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error)
+	ServiceRegisterFunc func(reg *api.AgentServiceRegistration) error
+}
+
+func (m *MockAgent) Service(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
+	if m.ServiceFunc != nil {
+		return m.ServiceFunc(serviceID, q)
+	}
+	return &api.AgentService{
+		ID:      "test-service",
+		Service: "test",
+		Tags:    []string{"tagged:old", "other-tag"},
+	}, nil, nil
+}
+
+func (m *MockAgent) ServiceRegister(reg *api.AgentServiceRegistration) error {
+	if m.ServiceRegisterFunc != nil {
+		return m.ServiceRegisterFunc(reg)
+	}
+	return nil
+}
+
+func TestCleanupCmdWithMockFactory(t *testing.T) {
+	// Save and restore the original factory
+	originalFactory := consul.Factory
+	defer func() {
+		consul.Factory = originalFactory
+	}()
+
+	t.Run("Successful cleanup with mock", func(t *testing.T) {
+		// Create a mock agent that simulates a service with tags
+		mockAgent := &MockAgent{
+			ServiceFunc: func(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
+				return &api.AgentService{
+					ID:      serviceID,
+					Service: "test",
+					Tags:    []string{"tagged-value1", "tagged-value2", "other-tag"},
+				}, nil, nil
+			},
+			ServiceRegisterFunc: func(reg *api.AgentServiceRegistration) error {
+				// Verify that the tags were cleaned up
+				assert.Equal(t, "test-service", reg.ID)
+				assert.NotContains(t, reg.Tags, "tagged-value1")
+				assert.NotContains(t, reg.Tags, "tagged-value2")
+				assert.Contains(t, reg.Tags, "other-tag")
+				return nil
+			},
+		}
+
+		// Create mock client with the mock agent
+		mockClient := &MockConsulClient{
+			MockAgent: mockAgent,
+		}
+
+		// Set up the mock factory
+		mockFactory := &consul.MockFactory{
+			MockClient: mockClient,
+		}
+		consul.SetFactory(mockFactory)
+
+		// Create a new command instance for this test
+		cmd := &cobra.Command{
+			Use:  "cleanup",
+			RunE: cleanupCmd.RunE,
+		}
+		// Set up parent command for flags inheritance
+		parent := &cobra.Command{}
+		parent.PersistentFlags().String("consul-addr", "127.0.0.1:8500", "")
+		parent.PersistentFlags().String("token", "", "")
+		parent.PersistentFlags().String("service-id", "test-service", "")
+		parent.PersistentFlags().String("tag-prefix", "tagged", "")
+		parent.AddCommand(cmd)
+
+		// Run the actual cleanup command
+		err := cmd.RunE(cmd, []string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Cleanup with connection error", func(t *testing.T) {
+		// Set up a factory that returns an error
+		mockFactory := &consul.MockFactory{
+			MockError: fmt.Errorf("connection failed"),
+		}
+		consul.SetFactory(mockFactory)
+
+		// Create a new command instance for this test
+		cmd := &cobra.Command{
+			Use:  "cleanup",
+			RunE: cleanupCmd.RunE,
+		}
+		// Set up parent command for flags inheritance
+		parent := &cobra.Command{}
+		parent.PersistentFlags().String("consul-addr", "127.0.0.1:8500", "")
+		parent.PersistentFlags().String("token", "", "")
+		parent.PersistentFlags().String("service-id", "test-service", "")
+		parent.PersistentFlags().String("tag-prefix", "tagged", "")
+		parent.AddCommand(cmd)
+
+		// Run the cleanup command - should fail
+		err := cmd.RunE(cmd, []string{})
+		assert.Error(t, err)
+	})
+
+	t.Run("Cleanup with service not found", func(t *testing.T) {
+		// Create a mock agent that returns nil service
+		mockAgent := &MockAgent{
+			ServiceFunc: func(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
+				return nil, nil, nil
+			},
+		}
+
+		// Create mock client with the mock agent
+		mockClient := &MockConsulClient{
+			MockAgent: mockAgent,
+		}
+
+		// Set up the mock factory
+		mockFactory := &consul.MockFactory{
+			MockClient: mockClient,
+		}
+		consul.SetFactory(mockFactory)
+
+		// Create a new command instance for this test
+		cmd := &cobra.Command{
+			Use:  "cleanup",
+			RunE: cleanupCmd.RunE,
+		}
+		// Set up parent command for flags inheritance
+		parent := &cobra.Command{}
+		parent.PersistentFlags().String("consul-addr", "127.0.0.1:8500", "")
+		parent.PersistentFlags().String("token", "", "")
+		parent.PersistentFlags().String("service-id", "test-service", "")
+		parent.PersistentFlags().String("tag-prefix", "tagged", "")
+		parent.AddCommand(cmd)
+
+		// Run the cleanup command - should fail
+		err := cmd.RunE(cmd, []string{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "service test-service not found")
+	})
+
+	t.Run("Cleanup with service register error", func(t *testing.T) {
+		// Create a mock agent that simulates a service with tags but fails on register
+		mockAgent := &MockAgent{
+			ServiceFunc: func(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
+				return &api.AgentService{
+					ID:      serviceID,
+					Service: "test",
+					Tags:    []string{"tagged-value1", "other-tag"},
+				}, nil, nil
+			},
+			ServiceRegisterFunc: func(reg *api.AgentServiceRegistration) error {
+				return fmt.Errorf("failed to register service")
+			},
+		}
+
+		// Create mock client with the mock agent
+		mockClient := &MockConsulClient{
+			MockAgent: mockAgent,
+		}
+
+		// Set up the mock factory
+		mockFactory := &consul.MockFactory{
+			MockClient: mockClient,
+		}
+		consul.SetFactory(mockFactory)
+
+		// Create a new command instance for this test
+		cmd := &cobra.Command{
+			Use:  "cleanup",
+			RunE: cleanupCmd.RunE,
+		}
+		// Set up parent command for flags inheritance
+		parent := &cobra.Command{}
+		parent.PersistentFlags().String("consul-addr", "127.0.0.1:8500", "")
+		parent.PersistentFlags().String("token", "", "")
+		parent.PersistentFlags().String("service-id", "test-service", "")
+		parent.PersistentFlags().String("tag-prefix", "tagged", "")
+		parent.AddCommand(cmd)
+
+		// Run the cleanup command - should fail
+		err := cmd.RunE(cmd, []string{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to clean up tags")
+	})
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/ncode/tagit/pkg/consul"
 	"github.com/ncode/tagit/pkg/tagit"
 	"github.com/spf13/cobra"
 )
@@ -59,22 +59,21 @@ example: tagit run -s my-super-service -x '/tmp/tag-role.sh'
 			return fmt.Errorf("invalid interval %q: %w", interval, err)
 		}
 
-		config := api.DefaultConfig()
-		config.Address, err = cmd.InheritedFlags().GetString("consul-addr")
+		consulAddr, err := cmd.InheritedFlags().GetString("consul-addr")
 		if err != nil {
 			logger.Error("Failed to get consul-addr flag", "error", err)
 			return err
 		}
-		config.Token, err = cmd.InheritedFlags().GetString("token")
+		token, err := cmd.InheritedFlags().GetString("token")
 		if err != nil {
 			logger.Error("Failed to get token flag", "error", err)
 			return err
 		}
 
-		consulClient, err := api.NewClient(config)
+		consulClient, err := consul.CreateClient(consulAddr, token)
 		if err != nil {
 			logger.Error("Failed to create Consul client", "error", err)
-			return fmt.Errorf("failed to create Consul client: %w", err)
+			return err
 		}
 
 		serviceID, err := cmd.InheritedFlags().GetString("service-id")
@@ -94,7 +93,7 @@ example: tagit run -s my-super-service -x '/tmp/tag-role.sh'
 		}
 
 		t := tagit.New(
-			tagit.NewConsulAPIWrapper(consulClient),
+			consulClient,
 			&tagit.CmdExecutor{},
 			serviceID,
 			script,

--- a/pkg/consul/factory.go
+++ b/pkg/consul/factory.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2025 Juliano Martinez <juliano@martinez.io>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package consul
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/api"
+)
+
+// ConsulClient is an interface for the Consul client.
+type ConsulClient interface {
+	Agent() ConsulAgent
+}
+
+// ConsulAgent is an interface for the Consul agent.
+type ConsulAgent interface {
+	Service(string, *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error)
+	ServiceRegister(*api.AgentServiceRegistration) error
+}
+
+// ConsulAPIWrapper wraps the Consul API client to conform to the ConsulClient interface.
+type ConsulAPIWrapper struct {
+	client *api.Client
+}
+
+// NewConsulAPIWrapper creates a new instance of ConsulAPIWrapper.
+func NewConsulAPIWrapper(client *api.Client) *ConsulAPIWrapper {
+	return &ConsulAPIWrapper{client: client}
+}
+
+// Agent returns an object that conforms to the ConsulAgent interface.
+func (w *ConsulAPIWrapper) Agent() ConsulAgent {
+	return w.client.Agent()
+}
+
+// ClientFactory is an interface for creating Consul clients
+type ClientFactory interface {
+	NewClient(address, token string) (ConsulClient, error)
+}
+
+// DefaultFactory creates real Consul clients
+type DefaultFactory struct{}
+
+// NewClient creates a new Consul client with the given configuration
+func (f *DefaultFactory) NewClient(address, token string) (ConsulClient, error) {
+	config := api.DefaultConfig()
+	config.Address = address
+	config.Token = token
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Consul client: %w", err)
+	}
+
+	return NewConsulAPIWrapper(client), nil
+}
+
+// MockFactory creates mock Consul clients for testing
+type MockFactory struct {
+	MockClient ConsulClient
+	MockError  error
+}
+
+// NewClient returns the mock client or error
+func (f *MockFactory) NewClient(address, token string) (ConsulClient, error) {
+	if f.MockError != nil {
+		return nil, f.MockError
+	}
+	return f.MockClient, nil
+}
+
+// Factory is the global factory instance (can be overridden for testing)
+var Factory ClientFactory = &DefaultFactory{}
+
+// SetFactory allows tests to inject a mock factory
+func SetFactory(f ClientFactory) {
+	Factory = f
+}
+
+// ResetFactory resets to the default factory
+func ResetFactory() {
+	Factory = &DefaultFactory{}
+}
+
+// CreateClient is a convenience function that uses the global factory
+func CreateClient(address, token string) (ConsulClient, error) {
+	return Factory.NewClient(address, token)
+}

--- a/pkg/consul/factory_test.go
+++ b/pkg/consul/factory_test.go
@@ -1,0 +1,123 @@
+package consul
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockConsulClient for testing
+type MockConsulClient struct {
+	MockAgent *MockAgent
+}
+
+func (m *MockConsulClient) Agent() ConsulAgent {
+	return m.MockAgent
+}
+
+type MockAgent struct {
+	ServiceFunc         func(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error)
+	ServiceRegisterFunc func(reg *api.AgentServiceRegistration) error
+}
+
+func (m *MockAgent) Service(serviceID string, q *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error) {
+	if m.ServiceFunc != nil {
+		return m.ServiceFunc(serviceID, q)
+	}
+	return nil, nil, nil
+}
+
+func (m *MockAgent) ServiceRegister(reg *api.AgentServiceRegistration) error {
+	if m.ServiceRegisterFunc != nil {
+		return m.ServiceRegisterFunc(reg)
+	}
+	return nil
+}
+
+func TestDefaultFactory(t *testing.T) {
+	factory := &DefaultFactory{}
+
+	// Test with valid configuration
+	// Note: This will actually try to connect to Consul, so it might fail
+	// in environments without Consul running
+	t.Run("Create client with valid config", func(t *testing.T) {
+		client, err := factory.NewClient("127.0.0.1:8500", "test-token")
+		// We expect this to succeed in creating a client object,
+		// even if Consul isn't actually running
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+}
+
+func TestMockFactory(t *testing.T) {
+	t.Run("Returns mock client", func(t *testing.T) {
+		mockClient := &MockConsulClient{
+			MockAgent: &MockAgent{},
+		}
+		factory := &MockFactory{
+			MockClient: mockClient,
+		}
+
+		client, err := factory.NewClient("any-address", "any-token")
+		assert.NoError(t, err)
+		assert.Equal(t, mockClient, client)
+	})
+
+	t.Run("Returns error when configured", func(t *testing.T) {
+		expectedErr := fmt.Errorf("connection failed")
+		factory := &MockFactory{
+			MockError: expectedErr,
+		}
+
+		client, err := factory.NewClient("any-address", "any-token")
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.Nil(t, client)
+	})
+}
+
+func TestGlobalFactory(t *testing.T) {
+	// Save original factory
+	originalFactory := Factory
+	defer func() {
+		Factory = originalFactory
+	}()
+
+	t.Run("Default factory is set", func(t *testing.T) {
+		ResetFactory()
+		_, ok := Factory.(*DefaultFactory)
+		assert.True(t, ok, "Default factory should be DefaultFactory type")
+	})
+
+	t.Run("Can set mock factory", func(t *testing.T) {
+		mockFactory := &MockFactory{
+			MockClient: &MockConsulClient{},
+		}
+		SetFactory(mockFactory)
+		assert.Equal(t, mockFactory, Factory)
+	})
+
+	t.Run("CreateClient uses global factory", func(t *testing.T) {
+		mockClient := &MockConsulClient{
+			MockAgent: &MockAgent{},
+		}
+		mockFactory := &MockFactory{
+			MockClient: mockClient,
+		}
+		SetFactory(mockFactory)
+
+		client, err := CreateClient("test-addr", "test-token")
+		assert.NoError(t, err)
+		assert.Equal(t, mockClient, client)
+	})
+
+	t.Run("ResetFactory restores default", func(t *testing.T) {
+		mockFactory := &MockFactory{}
+		SetFactory(mockFactory)
+		ResetFactory()
+		_, ok := Factory.(*DefaultFactory)
+		assert.True(t, ok, "Factory should be reset to DefaultFactory")
+	})
+}

--- a/pkg/tagit/tagit.go
+++ b/pkg/tagit/tagit.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/hashicorp/consul/api"
+	"github.com/ncode/tagit/pkg/consul"
 )
 
 // TagIt is the main struct for the tagit flow.
@@ -19,36 +20,11 @@ type TagIt struct {
 	Script          string
 	Interval        time.Duration
 	TagPrefix       string
-	client          ConsulClient
+	client          consul.ConsulClient
 	commandExecutor CommandExecutor
 	logger          *slog.Logger
 }
 
-// ConsulClient is an interface for the Consul client.
-type ConsulClient interface {
-	Agent() ConsulAgent
-}
-
-// ConsulAgent is an interface for the Consul agent.
-type ConsulAgent interface {
-	Service(string, *api.QueryOptions) (*api.AgentService, *api.QueryMeta, error)
-	ServiceRegister(*api.AgentServiceRegistration) error
-}
-
-// ConsulAPIWrapper wraps the Consul API client to conform to the ConsulClient interface.
-type ConsulAPIWrapper struct {
-	client *api.Client
-}
-
-// NewConsulAPIWrapper creates a new instance of ConsulAPIWrapper.
-func NewConsulAPIWrapper(client *api.Client) *ConsulAPIWrapper {
-	return &ConsulAPIWrapper{client: client}
-}
-
-// Agent returns an object that conforms to the ConsulAgent interface.
-func (w *ConsulAPIWrapper) Agent() ConsulAgent {
-	return w.client.Agent()
-}
 
 // CommandExecutor is an interface for running commands.
 type CommandExecutor interface {
@@ -72,7 +48,7 @@ func (e *CmdExecutor) Execute(command string) ([]byte, error) {
 }
 
 // New creates a new TagIt struct.
-func New(consulClient ConsulClient, commandExecutor CommandExecutor, serviceID string, script string, interval time.Duration, tagPrefix string, logger *slog.Logger) *TagIt {
+func New(consulClient consul.ConsulClient, commandExecutor CommandExecutor, serviceID string, script string, interval time.Duration, tagPrefix string, logger *slog.Logger) *TagIt {
 	return &TagIt{
 		ServiceID:       serviceID,
 		Script:          script,


### PR DESCRIPTION
This pull request refactors Consul client handling to use a new interface-based abstraction, improving testability and decoupling command logic from direct dependency on the HashiCorp Consul API. It introduces a factory pattern for Consul client creation, allowing easy mocking in tests, and updates both the `run` and `cleanup` commands and their tests to use this new approach. The changes also add comprehensive tests for various edge cases using the new mock infrastructure.

Consul client abstraction and factory pattern:

* Introduced `ConsulClient` and `ConsulAgent` interfaces, along with a `ClientFactory` abstraction in `pkg/consul/factory.go`, enabling dependency injection and easier mocking for tests. Added `DefaultFactory` for real clients and `MockFactory` for test clients. (`[pkg/consul/factory.goR1-R102](diffhunk://#diff-1142f61e0e32cf8339152cc77944982a9586034efa8d560f7b1bf950d664cdcfR1-R102)`)
* Replaced direct usage of `github.com/hashicorp/consul/api` in `cmd/cleanup.go` and `cmd/run.go` with the new factory-based approach, using `consul.CreateClient` for client instantiation. (`[[1]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868L23-R23)`, `[[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L27-R27)`)
* Updated command logic in `cmd/cleanup.go` and `cmd/run.go` to use the new interfaces and removed direct references to API-specific types, passing the abstracted client to `tagit.New`. (`[[1]](diffhunk://#diff-1af21b9d6fc06756cac01f80ce66e7e10df29ff796851fb52e0870501b111868L37-R50)`, `[[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L62-R76)`, `[[3]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349L97-R96)`)

Testing improvements:

* Added extensive mocking infrastructure and test cases in `cmd/cleanup_test.go` and `cmd/run_test.go` to cover success, error, and edge scenarios for both commands. Tests now use `consul.SetFactory` to inject mock clients, verifying correct behavior without requiring a real Consul server. (`[[1]](diffhunk://#diff-88bf4cf247b2469ebabdf721d68b5a01087e99ac1688ef053dc13b7f23dc7b7eR250-R279)`, `[[2]](diffhunk://#diff-88bf4cf247b2469ebabdf721d68b5a01087e99ac1688ef053dc13b7f23dc7b7eR291-R501)`, `[[3]](diffhunk://#diff-e5c6b0d9de21f1d8dee56a4b65988b10e5e74030b7dd52ef18195901e6f879adR489-R681)`)
* Updated imports in test files to support the new abstraction and mock types. (`[[1]](diffhunk://#diff-88bf4cf247b2469ebabdf721d68b5a01087e99ac1688ef053dc13b7f23dc7b7eR5-R9)`, `[[2]](diffhunk://#diff-e5c6b0d9de21f1d8dee56a4b65988b10e5e74030b7dd52ef18195901e6f879adR11-R12)`)