### PR TITLE
fix the re-tag bug

### DIFF
--- a/pkg/tagit/tagit_test.go
+++ b/pkg/tagit/tagit_test.go
@@ -195,6 +195,13 @@ func TestNeedsTag(t *testing.T) {
 			expectedTags:   []string{"tag2", "tag3", "tag4", "tag5"},
 			expectedShould: true,
 		},
+		{
+			name:           "No Update When Prefixed Tags Unchanged",
+			current:        []string{"tag-tag1", "tag-tag2", "other-tag", "another-tag"},
+			update:         []string{"tag-tag1", "tag-tag2"},
+			expectedTags:   nil,
+			expectedShould: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request updates the tag comparison logic in the `TagIt` service to ensure only prefixed tags are considered for updates, while preserving non-prefixed tags. It also adds a new test case to verify that no update occurs when prefixed tags remain unchanged.

Tag comparison logic improvements:

* Modified `needsTag` in `pkg/tagit/tagit.go` to extract prefixed and non-prefixed tags, compare only prefixed tags with the update, and combine non-prefixed tags with the updated tags for the result. This prevents unnecessary updates and ensures original non-prefixed tags are retained.

Test coverage enhancements:

* Added a test case to `TestNeedsTag` in `pkg/tagit/tagit_test.go` to verify that no update occurs when prefixed tags are unchanged, improving reliability of the tag update logic.